### PR TITLE
Use env vars to specify MAVSDK host, QGC host, and PX4 instance # for multiple drone simulations

### DIFF
--- a/edit_rcS.bash
+++ b/edit_rcS.bash
@@ -21,9 +21,10 @@ function get_vm_host_ip {
 }
 
 function get_px4_client_ip {
-    # Generates an IPv4 address (172.19.0.1) which points to the px4-client Docker container    
-    # TODO investigate more robust networking options: if px4-client container restarts, the IP will change, requiring this simulator to obtain the new IP and restart the mavsdk server
-    echo "$(dig px4-client +short)"
+    # Generates an IPv4 address (172.19.0.1) which points to the PX4 client Docker container
+    # TODO investigate more robust networking options: if PX4 client container restarts, the IP will change, requiring this simulator to obtain the new IP and restart the mavsdk server
+    PX4_CLIENT_HOST=${PX4_CLIENT_HOST:-"px4-client"}
+    echo "$(dig $PX4_CLIENT_HOST +short)"
 }
 
 function get_host_ip {
@@ -35,6 +36,7 @@ if is_docker_vm; then
     VM_HOST=$(get_vm_host_ip)
     PX4_CLIENT_HOST=$(get_px4_client_ip)
     echo "VM host IP: ${VM_HOST}"
+    echo "PX4 client IP: ${PX4_CLIENT_HOST}"
     QGC_PARAM=${QGC_PARAM:-"-t ${VM_HOST}"}
     API_PARAM=${API_PARAM:-"-t ${PX4_CLIENT_HOST}"}
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,8 +9,8 @@ function show_help {
     echo "(i.e. when running e.g. \`make px4_sitl gazebo_iris__baylands\`)"
     echo ""
     echo "  -h    Show this help"
-    echo "  -v    Set the vehicle (default: iris)"
-    echo "  -w    Set the world (default: empty)"
+    echo "  -v    Set the vehicle (default: gz_x500)"
+    echo "  -w    Set the world (default: default)"
     echo ""
     echo "  <HOST_API> is the host or IP to which PX4 will send MAVLink on UDP port 14540"
     echo "  <HOST_QGC> is the host or IP to which PX4 will send MAVLink on UDP port 14550"
@@ -50,19 +50,19 @@ done
 
 shift $((OPTIND-1))
 
-
-if [ "$#" -eq 1 ]; then
-    IP_QGC=$(get_ip "$1")
-elif [ "$#" -eq 2 ]; then
-    IP_API=$(get_ip "$1")
-    IP_QGC=$(get_ip "$2")
-elif [ "$#" -gt 2 ]; then
-    show_help
-    exit 1;
+# Rely on environment variables for offboard API (MAVSDK) IP address, QGroundControl IP address, and PX4 instance ID
+if [ -n "${IP_API}" ]; then
+    IP_API=$(get_ip "${IP_API}")
 fi
+
+if [ -n "${IP_QGC}" ]; then
+    IP_QGC=$(get_ip "${IP_QGC}")
+fi
+
+INSTANCE_NUM=${INSTANCE_NUM:-0}
 
 Xvfb :99 -screen 0 1600x1200x24+32 &
 ${SITL_RTSP_PROXY}/build/sitl_rtsp_proxy &
 
 source ${WORKSPACE_DIR}/edit_rcS.bash ${IP_API} ${IP_QGC} &&
-HEADLESS=1 PX4_SIM_MODEL=${vehicle} PX4_GZ_WORLD=${world} ${FIRMWARE_DIR}/build/bin/px4
+HEADLESS=1 PX4_SIM_MODEL=${vehicle} PX4_GZ_WORLD=${world} ${FIRMWARE_DIR}/build/bin/px4 -i ${INSTANCE_NUM}


### PR DESCRIPTION
## Overview

Instead of using ordered CLI arguments like the source repo (https://github.com/JonasVautherin/px4-gazebo-headless/), we will use environment variables for each PX4 Gazebo sim container to determine:

* IP address that MAVLink commands will be sent to/received from
* IP address of QGroundControl (not required for Urza, but very helpful for debugging)
* Drone instance number*

\* Future PR(s) to add feature enabling multiple-UAV simulation (see https://github.com/PX4/PX4-Autopilot/blob/main/Tools/simulation/sitl_multiple_run.sh)