### PR TITLE
Set home to Port Hueneme

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -78,12 +78,12 @@ while [ $n -lt $NUM_DRONES ]; do
     pushd "$working_dir" &>/dev/null
     echo "starting instance $n in $(pwd)"
     # PX4_GZ_MODEL_POSE (x, y, z, roll, pitch, yaw) should be unique for each instance to avoid collisions on initialization
-        HEADLESS=1 PX4_SIM_MODEL=${vehicle} PX4_GZ_WORLD=${world} PX4_GZ_MODEL_POSE="0,$n,0,0,0,0" ${PX4_BUILD_DIR}/bin/px4 -d -i $n &
+    HEADLESS=1 PX4_SIM_MODEL=${vehicle} PX4_GZ_WORLD=${world} PX4_GZ_MODEL_POSE="$(($n * 20)),0,0,0,0,0" ${PX4_BUILD_DIR}/bin/px4 -d -i $n &
     popd &>/dev/null
         
     # Increased sleep time between subsequent instance launches
-    echo "Sleeping 20 seconds before launching next instance..."
-    sleep 20
+    echo "Sleeping 10 seconds before launching next instance..."
+    sleep 10
     
     n=$(($n + 1))
 done

--- a/simulation-worlds/port-hueneme.sdf
+++ b/simulation-worlds/port-hueneme.sdf
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sdf version="1.9">
+  <world name="default">
+    <physics type="ode">
+      <max_step_size>0.004</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+      <real_time_update_rate>250</real_time_update_rate>
+    </physics>
+    <gravity>0 0 -9.8</gravity>
+    <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>
+    <atmosphere type="adiabatic"/>
+    <scene>
+      <grid>false</grid>
+      <ambient>0.4 0.4 0.4 1</ambient>
+      <background>0.7 0.7 0.7 1</background>
+      <shadows>true</shadows>
+    </scene>
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>1 1</size>
+            </plane>
+          </geometry>
+          <surface>
+            <friction>
+              <ode/>
+            </friction>
+            <bounce/>
+            <contact/>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>500 500</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+        <pose>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>1</mass>
+          <inertia>
+            <ixx>1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>1</iyy>
+            <iyz>0</iyz>
+            <izz>1</izz>
+          </inertia>
+        </inertial>
+        <enable_wind>false</enable_wind>
+      </link>
+      <pose>0 0 0 0 -0 0</pose>
+      <self_collide>false</self_collide>
+    </model>
+    <light name="sunUTC" type="directional">
+      <pose>0 0 500 0 -0 0</pose>
+      <cast_shadows>true</cast_shadows>
+      <intensity>1</intensity>
+      <direction>0.001 0.625 -0.78</direction>
+      <diffuse>0.904 0.904 0.904 1</diffuse>
+      <specular>0.271 0.271 0.271 1</specular>
+      <attenuation>
+        <range>2000</range>
+        <linear>0</linear>
+        <constant>1</constant>
+        <quadratic>0</quadratic>
+      </attenuation>
+      <spot>
+        <inner_angle>0</inner_angle>
+        <outer_angle>0</outer_angle>
+        <falloff>0</falloff>
+      </spot>
+    </light>
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>34.14414613192739</latitude_deg>
+      <longitude_deg>-119.19982515058868</longitude_deg>
+      <elevation>10</elevation>
+    </spherical_coordinates>
+  </world>
+</sdf>


### PR DESCRIPTION
## Jira Tickets

Primary:
- Update mission start location to Port Hueneme <https://nodaai.atlassian.net/browse/URZA-489>
- Update UAV start locations to not overlap <https://nodaai.atlassian.net/browse/URZA-490>

## Changes

- Updated `entrypoint.sh` script:
  - Spaced out the PX4 instances by 20m starting from the home location specified in `port-hueneme.sdf`
  - Shortened sleep time from 20 to 10 seconds for starting PX4 instances (seems stable for now)
- Added `.sdf` file for Port Hueneme

## Testing

Tested by running Urza using the new image:

[spaced-out-px4-in-port-hueneme.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/YMb7Y9P7KZ1OHQzUJjJO/61db25a8-5a14-4cde-8fe6-1ba48ffb99af.mov" />](https://app.graphite.dev/media/video/YMb7Y9P7KZ1OHQzUJjJO/61db25a8-5a14-4cde-8fe6-1ba48ffb99af.mov)

